### PR TITLE
Update to Pi-hole v4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ End of day one
 │   └── pihole
 │       ├── dnsmasq.conf
 │       ├── gravity.list
+│       ├── pihole-FTL.conf
 │       ├── pihole-FTL.db
 │       └── setupVars.conf
 └── var

--- a/configs/pihole-FTL.conf
+++ b/configs/pihole-FTL.conf
@@ -1,0 +1,12 @@
+DBFILE=/var/snap/pihole/common/etc/pihole/pihole-FTL.db
+LOGFILE=/var/snap/pihole/common/var/log/pihole-FTL.log
+PIDFILE=/var/snap/pihole/common/var/run/pihole-FTL.pid
+PORTFILE=/var/snap/pihole/common/var/run/pihole-FTL.port
+SOCKETFILE=/var/snap/pihole/common/var/run/pihole/FTL.sock
+WHITELISTFILE=/var/snap/pihole/common/etc/pihole/whitelist.txt
+BLACKLISTFILE=/var/snap/pihole/common/etc/pihole/black.list
+GRAVITYFILE=/var/snap/pihole/common/etc/pihole/gravity.list
+REGEXLISTFILE=/var/snap/pihole/common/etc/pihole/regex.list
+SETUPVARSFILE=/var/snap/pihole/common/etc/pihole/setupVars.conf
+AUDITLISTFILE=/var/snap/pihole/common/etc/pihole/auditlog.list
+

--- a/patches/fix-confined-paths.patch
+++ b/patches/fix-confined-paths.patch
@@ -1,15 +1,3 @@
-diff -Naur FTL/config.c FTL-snap/config.c
---- FTL/config.c	2018-11-06 22:57:03.682524106 +0000
-+++ FTL-snap/config.c	2018-11-06 23:22:51.553438618 +0000
-@@ -124,7 +124,7 @@
- 	if(!(buffer != NULL && sscanf(buffer, "%127ms", &FTLfiles.db)))
- 	{
- 		// Use standard path if no custom path was obtained from the config file
--		FTLfiles.db = strdup("/etc/pihole/pihole-FTL.db");
-+		FTLfiles.db = strdup("/var/snap/pihole/common/etc/pihole/pihole-FTL.db");
- 	}
- 
- 	// Test if memory allocation was successful
 diff -Naur FTL/dnsmasq/config.h FTL-snap/dnsmasq/config.h
 --- FTL/dnsmasq/config.h	2018-11-06 22:57:03.686524083 +0000
 +++ FTL-snap/dnsmasq/config.h	2018-11-06 23:22:48.437456951 +0000
@@ -22,48 +10,6 @@ diff -Naur FTL/dnsmasq/config.h FTL-snap/dnsmasq/config.h
  #    endif
  #endif
  
-diff -Naur FTL/memory.c FTL-snap/memory.c
---- FTL/memory.c	2018-11-06 22:57:03.694524037 +0000
-+++ FTL-snap/memory.c	2018-11-06 23:22:53.065429721 +0000
-@@ -11,24 +11,24 @@
- #include "FTL.h"
- 
- FTLFileNamesStruct FTLfiles = {
--	"/etc/pihole/pihole-FTL.conf",
--	"/var/log/pihole-FTL.log",
--	"/var/run/pihole-FTL.pid",
--	"/var/run/pihole-FTL.port",
-+	"/var/snap/pihole/common/etc/pihole/pihole-FTL.conf",
-+	"/var/snap/pihole/common/var/log/pihole-FTL.log",
-+	"/var/snap/pihole/common/var/run/pihole-FTL.pid",
-+	"/var/snap/pihole/common/var/run/pihole-FTL.port",
- 	NULL,
--	"/var/run/pihole/FTL.sock"
-+	"/var/snap/pihole/common/var/run/pihole/FTL.sock"
- };
- 
- logFileNamesStruct files = {
--	"/var/log/pihole.log",
--	"/etc/pihole/list.preEventHorizon",
--	"/etc/pihole/whitelist.txt",
--	"/etc/pihole/black.list",
--	"/etc/pihole/gravity.list",
--	"/etc/pihole/regex.list",
--	"/etc/pihole/setupVars.conf",
--	"/etc/pihole/auditlog.list",
--	"/etc/dnsmasq.d/01-pihole.conf",
-+	"/var/snap/pihole/common/var/log/pihole.log",
-+	"/var/snap/pihole/common/etc/pihole/list.preEventHorizon",
-+	"/var/snap/pihole/common/etc/pihole/whitelist.txt",
-+	"/var/snap/pihole/common/etc/pihole/black.list",
-+	"/var/snap/pihole/common/etc/pihole/gravity.list",
-+	"/var/snap/pihole/common/etc/pihole/regex.list",
-+	"/var/snap/pihole/common/etc/pihole/setupVars.conf",
-+	"/var/snap/pihole/common/etc/pihole/auditlog.list",
-+	"/var/snap/pihole/common/etc/dnsmasq.d/01-pihole.conf",
- };
- 
- // Fixed size structs
 diff -Naur FTL/socket_client.c FTL-snap/socket_client.c
 --- FTL/socket_client.c	2018-11-06 22:57:03.694524037 +0000
 +++ FTL-snap/socket_client.c	2018-11-06 23:22:54.681420214 +0000
@@ -79,7 +25,7 @@ diff -Naur FTL/socket_client.c FTL-snap/socket_client.c
 diff -Naur FTL/sqlite3.c FTL-snap/sqlite3.c
 --- FTL/sqlite3.c	2018-11-06 22:57:03.738523780 +0000
 +++ FTL-snap/sqlite3.c	2018-11-06 23:22:22.913607124 +0000
-@@ -37234,8 +37234,8 @@
+@@ -37743,8 +37743,8 @@
    static const char *azDirs[] = {
       0,
       0,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,7 @@ parts:
       - libidn11-dev
       - m4
       - build-essential
+      - libhogweed4
     stage-packages:
       - whiptail
       - curl

--- a/wrapper
+++ b/wrapper
@@ -15,6 +15,7 @@ if [ ! -f $DNSMASQDDIR/01-pihole.conf ]; then
   cp $SNAP/configs/01-pihole.conf $DNSMASQDDIR/
   cp $SNAP/configs/setupVars.conf $CONFIGDIR/
   cp $SNAP/configs/gravity.list $CONFIGDIR/
+  cp $SNAP/configs/pihole-FTL.conf $CONFIGDIR/
   ln -s $DNSMASQDDIR/01-pihole.conf $SNAP_COMMON/etc/dnsmasq.conf
 fi
 while :; do


### PR DESCRIPTION
This also fixes FTL failing to compile due to not having libhogweed. The custom paths are largely moved from the patches to FTL's config file.